### PR TITLE
Redirect to /login after we log out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 1.2.11
+
+* Fixed:        Logout redirects to given url to prevent NotLoggedInException from /login?logout=1
+
 ### 1.2.10
 
 * Changed:      Automatically redirecting to previous URL after login 

--- a/src/LoginProviders/LoginProvider.php
+++ b/src/LoginProviders/LoginProvider.php
@@ -20,12 +20,15 @@ namespace Rhubarb\Scaffolds\Authentication\LoginProviders;
 
 use Rhubarb\Crown\DateTime\RhubarbDateTime;
 use Rhubarb\Crown\Encryption\HashProvider;
+use Rhubarb\Crown\Exceptions\ForceResponseException;
 use Rhubarb\Crown\Http\HttpResponse;
 use Rhubarb\Crown\Logging\Log;
 use Rhubarb\Crown\LoginProviders\CredentialsLoginProviderInterface;
 use Rhubarb\Crown\LoginProviders\Exceptions\CredentialsFailedException;
 use Rhubarb\Crown\LoginProviders\Exceptions\LoginFailedException;
+use Rhubarb\Crown\LoginProviders\Exceptions\NotLoggedInException;
 use Rhubarb\Crown\Request\Request;
+use Rhubarb\Crown\Response\RedirectResponse;
 use Rhubarb\Scaffolds\Authentication\Exceptions\LoginDisabledException;
 use Rhubarb\Scaffolds\Authentication\Exceptions\LoginTemporarilyLockedOutException;
 use Rhubarb\Scaffolds\Authentication\Exceptions\LoginExpiredException;
@@ -386,6 +389,8 @@ class LoginProvider extends ModelLoginProvider implements CredentialsLoginProvid
         parent::onLogOut();
         HttpResponse::unsetCookie('lun');
         HttpResponse::unsetCookie('ltk');
+        // Preventing us getting stuck at /login?logout=1 and getting a NotLoggedInException when we log in
+        throw new ForceResponseException(new RedirectResponse('/login'));
     }
 
     /**

--- a/src/LoginProviders/LoginProvider.php
+++ b/src/LoginProviders/LoginProvider.php
@@ -51,6 +51,8 @@ class LoginProvider extends ModelLoginProvider implements CredentialsLoginProvid
     protected $passwordColumnName = "";
     protected $activeColumnName = "";
 
+    protected $logoutRedirectUrl = '/';
+
     /**
      * @var LoginProviderSettings
      */
@@ -389,8 +391,11 @@ class LoginProvider extends ModelLoginProvider implements CredentialsLoginProvid
         parent::onLogOut();
         HttpResponse::unsetCookie('lun');
         HttpResponse::unsetCookie('ltk');
-        // Preventing us getting stuck at /login?logout=1 and getting a NotLoggedInException when we log in
-        throw new ForceResponseException(new RedirectResponse('/login'));
+
+        // Log out redirection prevents a NotLoggedInException when we log in from /login?logout=1
+        if ($this->logoutRedirectUrl) {
+            throw new ForceResponseException(new RedirectResponse($this->logoutRedirectUrl));
+        }
     }
 
     /**


### PR DESCRIPTION
* login/?logout=1 was logging out but maintaining the url, meaning when we log back in we get a NotLoggedInException :(