### PR TITLE
ActivateAccount renamed to AccountOnboarding

### DIFF
--- a/src/AuthenticationModule.php
+++ b/src/AuthenticationModule.php
@@ -94,7 +94,10 @@ class AuthenticationModule extends Module
                         $className = $url->logoutLeafClassName;
                         return new $className($provider, $url->loginProviderClassName);
                     }),
-                    $url->activateChildUrl => $activate = new LeafCollectionUrlHandler($url->activatePasswordLeafClassName,$url->activatePasswordLeafClassName),
+                    $url->onboardingChildUrl => $activate = new GreedyUrlHandler(function ($parentHandler, $captured) use ($url, $provider) {
+                        $className = $url->onboardingPasswordLeafClassName;
+                        return new $className($provider, $captured);
+                    })
                 ]),
                 $url->urlToProtect => $protected =
                     new ValidateLoginUrlHandler($provider, $url->loginUrl),

--- a/src/Emails/AccountOnboardingInvitationEmail.php
+++ b/src/Emails/AccountOnboardingInvitationEmail.php
@@ -3,8 +3,9 @@
 namespace Rhubarb\Scaffolds\Authentication\Emails;
 
 use Rhubarb\Crown\Settings\WebsiteSettings;
+use Rhubarb\Scaffolds\Authentication\Settings\ProtectedUrl;
 
-class ActivateAccountInvitationEmail extends ResetPasswordInvitationEmail
+class AccountOnboardingInvitationEmail extends ResetPasswordInvitationEmail
 {
     public function getText()
     {
@@ -26,12 +27,12 @@ Text;
      */
     public function getSubject()
     {
-        return 'Activate Your Account';
+        return 'Create Your Account';
     }
 
     public function getHtmlHeading()
     {
-        return "<h1>Activate Your Account</h1>";
+        return "<h1>Create Your Account</h1>";
     }
 
     public function getHtmlBody()

--- a/src/Emails/ActivateAccountInvitationEmail.php
+++ b/src/Emails/ActivateAccountInvitationEmail.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rhubarb\Scaffolds\Authentication\Emails;
+
+/** @deprecated use AccountOnboardingInvitationEmail */
+class ActivateAccountInvitationEmail extends AccountOnboardingInvitationEmail
+{
+
+}

--- a/src/Leaves/AccountOnboarding.php
+++ b/src/Leaves/AccountOnboarding.php
@@ -2,10 +2,10 @@
 
 namespace Rhubarb\Scaffolds\Authentication\Leaves;
 
-class ActivateAccount extends ConfirmResetPassword
+class AccountOnboarding extends ConfirmResetPassword
 {
     protected function getViewClass()
     {
-        return ActivateAccountView::class;
+        return AccountOnboardingView::class;
     }
 }

--- a/src/Leaves/AccountOnboardingView.php
+++ b/src/Leaves/AccountOnboardingView.php
@@ -4,7 +4,7 @@ namespace Rhubarb\Scaffolds\Authentication\Leaves;
 
 use Rhubarb\Leaf\Controls\Common\Buttons\Button;
 
-class ActivateAccountView extends ConfirmResetPasswordView
+class AccountOnboardingView extends ConfirmResetPasswordView
 {
     protected function createSubLeaves()
     {
@@ -36,8 +36,8 @@ class ActivateAccountView extends ConfirmResetPasswordView
         $this->layoutItemsWithContainer($this->getTitle(),
             "<p class='c-form__help'>{$this->getTitleParagraph()}</p>",
             [
-                "Enter new password" => "newPassword",
-                "Enter again to confirm" => "confirmNewPassword",
+                "Create your password" => "newPassword",
+                "Confirm your password" => "confirmNewPassword",
                 "" => "ActivateAccount"
             ]
         );
@@ -45,12 +45,12 @@ class ActivateAccountView extends ConfirmResetPasswordView
 
     protected function getTitle()
     {
-        return "Activate your account";
+        return "Create your account";
     }
 
     protected function getTitleParagraph()
     {
-        return "Activate your account by setting your password.";
+        return "Create your account by setting your password.";
     }
 
     protected function getMessages()

--- a/src/Leaves/ActivateAccount.php
+++ b/src/Leaves/ActivateAccount.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rhubarb\Scaffolds\Authentication\Leaves;
+
+/** @deprecated use AccountOnboarding */
+class ActivateAccount extends AccountOnboarding
+{
+
+}

--- a/src/Leaves/ActivateAccountView.php
+++ b/src/Leaves/ActivateAccountView.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rhubarb\Scaffolds\Authentication\Leaves;
+
+/** @deprecated use AccountOnboardingView */
+class ActivateAccountView extends AccountOnboardingView
+{
+
+}

--- a/src/Settings/ProtectedUrl.php
+++ b/src/Settings/ProtectedUrl.php
@@ -2,7 +2,7 @@
 
 namespace Rhubarb\Scaffolds\Authentication\Settings;
 
-use Rhubarb\Scaffolds\Authentication\Leaves\ActivateAccount;
+use Rhubarb\Scaffolds\Authentication\Leaves\AccountOnboarding;
 use Rhubarb\Scaffolds\Authentication\Leaves\ConfirmResetPassword;
 use Rhubarb\Scaffolds\Authentication\Leaves\Login;
 use Rhubarb\Scaffolds\Authentication\Leaves\Logout;
@@ -23,8 +23,8 @@ class ProtectedUrl
     public $resetPasswordLeafClassName = ResetPassword::class;
     public $confirmResetPasswordLeafClassName = ConfirmResetPassword::class;
 
-    public $activateChildUrl = 'activate/';
-    public $activatePasswordLeafClassName = ActivateAccount::class;
+    public $onboardingChildUrl = 'activate/';
+    public $onboardingPasswordLeafClassName = AccountOnboarding::class;
 
     public function __construct($urlToProtect, $loginProviderClassName, $loginUrl)
     {

--- a/src/UseCases/SendAccountOnboardingInvitationEmailUseCase.php
+++ b/src/UseCases/SendAccountOnboardingInvitationEmailUseCase.php
@@ -4,15 +4,15 @@ namespace Rhubarb\Scaffolds\Authentication\Leaves;
 
 use Rhubarb\Crown\DependencyInjection\Container;
 use Rhubarb\Crown\Sendables\Email\EmailProvider;
-use Rhubarb\Scaffolds\Authentication\Emails\ActivateAccountInvitationEmail;
+use Rhubarb\Scaffolds\Authentication\Emails\AccountOnboardingInvitationEmail;
 use Rhubarb\Scaffolds\Authentication\User;
 
-class SendActivateAccountInvitationEmailUseCase
+class SendAccountOnboardingInvitationEmailUseCase
 {
     public static function execute(User $user)
     {
         $user->generatePasswordResetHash();
-        $resetPasswordEmail = Container::instance(ActivateAccountInvitationEmail::class, $user);
+        $resetPasswordEmail = Container::instance(AccountOnboardingInvitationEmail::class, $user);
         EmailProvider::selectProviderAndSend($resetPasswordEmail);
     }
 }

--- a/src/UseCases/SendActivateAccountInvitationEmailUseCase.php
+++ b/src/UseCases/SendActivateAccountInvitationEmailUseCase.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rhubarb\Scaffolds\Authentication\UseCases;
+
+use Rhubarb\Scaffolds\Authentication\Leaves\SendAccountOnboardingInvitationEmailUseCase;
+
+/** @deprecated use SendAccountOnboardingInvitiationEmailUseCase */
+class SendActivateAccountInvitationEmailUseCase extends SendAccountOnboardingInvitationEmailUseCase
+{
+
+}


### PR DESCRIPTION
Renamed activate account to onboarding as suggested in [pr 12](https://github.com/RhubarbPHP/Scaffold.Authentication/pull/12)

Brought AccountOnboarding up to date to use a greedy url handler to capture the password hash.

Changed wording of activate account view and email.