### PR TITLE
Fix for issue where a user can be logged out after Too Many Failed login attempts

### DIFF
--- a/src/LoginProviders/LoginProvider.php
+++ b/src/LoginProviders/LoginProvider.php
@@ -327,10 +327,10 @@ class LoginProvider extends ModelLoginProvider implements CredentialsLoginProvid
         $andGroupFilter->addFilters(new Equals("EnteredUsername", $user[$settings->identityColumnName]));
         $andGroupFilter->addFilters(new Equals("LogType", UserLog::USER_LOG_LOGIN_FAILED));
 
-        // Retrieve last successful login attempt
-        $lastSuccesfulLoginAttempt = UserLog::getLastSuccessfulLoginAttempt($user[$settings->identityColumnName]);
-        if ($lastSuccesfulLoginAttempt) {
-            $andGroupFilter->addFilters(new GreaterThan("UserLogID", $lastSuccesfulLoginAttempt->UserLogID));
+        // Retrieve last successful login attempt or Password Change Attempt
+        $lastSuccesfulLoginOrPasswordChangeAttempt = UserLog::getLastSuccessfulUserLoginOrPasswordChangeAttempt($user[$settings->identityColumnName], $user->getUniqueIdentifier());
+        if ($lastSuccesfulLoginOrPasswordChangeAttempt) {
+            $andGroupFilter->addFilters(new GreaterThan("UserLogID", $lastSuccesfulLoginOrPasswordChangeAttempt->UserLogID));
         }
 
         //  Get all failed login attempts from the last successful login if one can be found

--- a/src/UserLog.php
+++ b/src/UserLog.php
@@ -5,6 +5,7 @@ namespace Rhubarb\Scaffolds\Authentication;
 use Rhubarb\Stem\Exceptions\RecordNotFoundException;
 use Rhubarb\Stem\Filters\AndGroup;
 use Rhubarb\Stem\Filters\Equals;
+use Rhubarb\Stem\Filters\OrGroup;
 use Rhubarb\Stem\Models\Model;
 use Rhubarb\Stem\Repositories\MySql\Schema\Columns\MySqlEnumColumn;
 use Rhubarb\Stem\Schema\Columns\AutoIncrementColumn;
@@ -67,6 +68,44 @@ class UserLog extends Model
                     new Equals("LogType", self::USER_LOG_LOGIN_SUCCESSFUL)
                 ]
             ));
+        } catch (RecordNotFoundException $exception) {
+        }
+
+        return null;
+    }
+
+    public static function getLastSuccessfulPasswordChangeAttempt($userId)
+    {
+        try {
+            return self::findLast(new AndGroup(
+                [
+                    new Equals("UserID", $userId),
+                    new Equals("LogType", self::USER_LOG_PASSWORD_CHANGED)
+                ]
+            ));
+        } catch (RecordNotFoundException $exception) {
+        }
+
+        return null;
+    }
+
+    public static function getLastSuccessfulUserLoginOrPasswordChangeAttempt($username, $userId)
+    {
+        try {
+            return self::findLast(
+                new OrGroup([
+                    new AndGroup(
+                        [
+                            new Equals("EnteredUsername", $username),
+                            new Equals("LogType", self::USER_LOG_LOGIN_SUCCESSFUL)
+                        ]),
+                    new AndGroup(
+                        [
+                            new Equals("UserID", $userId),
+                            new Equals("LogType", self::USER_LOG_PASSWORD_CHANGED)
+                        ]),
+                ])
+            );
         } catch (RecordNotFoundException $exception) {
         }
 


### PR DESCRIPTION
Adding fix for a login issue where the Too Many Login attempts error would still shown to the user despite them having just changed their password.

The fix I have added will now retrieve either the most recent Password Changed or the Last Successful login attempt.

